### PR TITLE
Markdown fix in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,9 +238,7 @@ turned ON or OFF through CMake variables.
 
 All dependencies are supplied by the Fletch package of 3rd party dependencies.
 
-[Eigen](http://eigen.tuxfamily.org/) (>= 3.0)
-[log4cxx] (https://logging.apache.org/log4cxx/) (>= 0.10.0)
-[Apache Runtime] (https://apr.apache.org/)
+[Eigen](http://eigen.tuxfamily.org/) (>= 3.0) [log4cxx](https://logging.apache.org/log4cxx/) (>= 0.10.0) [Apache Runtime](https://apr.apache.org/)
 
 # Development #
 


### PR DESCRIPTION
Extraneous spaces in the markdown prevent links from being displayed properly.